### PR TITLE
Eliminate direct use of engine for runtime frameworks

### DIFF
--- a/src/nunit-gui/Presenters/XmlPresenter.cs
+++ b/src/nunit-gui/Presenters/XmlPresenter.cs
@@ -27,8 +27,6 @@ using System.IO;
 using System.Text;
 using System.Xml;
 
-using Mono.Cecil;
-
 namespace NUnit.Gui.Presenters
 {
     using Model;

--- a/src/nunit-gui/nunit-gui.csproj
+++ b/src/nunit-gui/nunit-gui.csproj
@@ -36,16 +36,8 @@
     <ApplicationIcon>nunit.ico</ApplicationIcon>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.6.1\lib\Mono.Cecil.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nunit.engine, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.6.1\lib\nunit.engine.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.6.1\lib\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.Api.3.6.1\lib\nunit.engine.api.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />

--- a/src/nunit-gui/packages.config
+++ b/src/nunit-gui/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit.Engine" version="3.6.1" targetFramework="net20" />
+  <package id="NUnit.Engine.Api" version="3.6.1" targetFramework="net20" />
 </packages>

--- a/src/nunit.gui.core/EnginePackageSettings.cs
+++ b/src/nunit.gui.core/EnginePackageSettings.cs
@@ -1,0 +1,157 @@
+﻿// ***********************************************************************
+// Copyright (c) 2016 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+namespace NUnit
+{
+    /// <summary>
+    /// EngineSettings contains constant values that
+    /// are used as keys in setting up a TestPackage. 
+    /// Values here are used in the engine, and set by the runner.
+    /// Setting values may be a string, int or bool.
+    /// </summary>
+    public static class EnginePackageSettings
+    {
+        #region Engine Settings - Used by the Engine itself
+
+        /// <summary>
+        /// The name of the config to use in loading a project.
+        /// If not specified, the first config found is used.
+        /// </summary>
+        public const string ActiveConfig = "ActiveConfig";
+
+        /// <summary>
+        /// Bool indicating whether the engine should determine the private
+        /// bin path by examining the paths to all the tests. Defaults to
+        /// true unless PrivateBinPath is specified.
+        /// </summary>
+        public const string AutoBinPath = "AutoBinPath";
+
+        /// <summary>
+        /// The ApplicationBase to use in loading the tests. If not 
+        /// specified, and each assembly has its own process, then the
+        /// location of the assembly is used. For multiple  assemblies
+        /// in a single process, the closest common root directory is used.
+        /// </summary>
+        public const string BasePath = "BasePath";
+
+        /// <summary>
+        /// Path to the config file to use in running the tests. 
+        /// </summary>
+        public const string ConfigurationFile = "ConfigurationFile";
+
+        /// <summary>
+        /// Flag (bool) indicating whether tests are being debugged.
+        /// </summary>
+        public const string DebugTests = "DebugTests";
+
+        /// <summary>
+        /// Bool flag indicating whether a debugger should be launched at agent 
+        /// startup. Used only for debugging NUnit itself.
+        /// </summary>
+        public const string DebugAgent = "DebugAgent";
+
+        /// <summary>
+        /// Indicates how to load tests across AppDomains. Values are:
+        /// "Default", "None", "Single", "Multiple". Default is "Multiple"
+        /// if more than one assembly is loaded in a process. Otherwise,
+        /// it is "Single".
+        /// </summary>
+        public const string DomainUsage = "DomainUsage";
+
+        /// <summary>
+        /// The private binpath used to locate assemblies. Directory paths
+        /// is separated by a semicolon. It's an error to specify this and
+        /// also set AutoBinPath to true.
+        /// </summary>
+        public const string PrivateBinPath = "PrivateBinPath";
+
+        /// <summary>
+        /// The maximum number of test agents permitted to run simultaneously. 
+        /// Ignored if the ProcessModel is not set or defaulted to Multiple.
+        /// </summary>
+        public const string MaxAgents = "MaxAgents";
+
+        /// <summary>
+        /// Indicates how to allocate assemblies to processes. Values are:
+        /// "Default", "Single", "Separate", "Multiple". Default is "Multiple"
+        /// for more than one assembly, "Separate" for a single assembly.
+        /// </summary>
+        public const string ProcessModel = "ProcessModel";
+
+        /// <summary>
+        /// Indicates the desired runtime to use for the tests. Values 
+        /// are strings like "net-4.5", "mono-4.0", etc. Default is to
+        /// use the target framework for which an assembly was built.
+        /// </summary>
+        public const string RuntimeFramework = "RuntimeFramework";
+
+        /// <summary>
+        /// Bool flag indicating that the test should be run in a 32-bit process 
+        /// on a 64-bit system. By default, NUNit runs in a 64-bit process on
+        /// a 64-bit system. Ignored if set on a 32-bit system.
+        /// </summary>
+        public const string RunAsX86 = "RunAsX86";
+
+        /// <summary>
+        /// Indicates that test runners should be disposed after the tests are executed
+        /// </summary>
+        public const string DisposeRunners = "DisposeRunners";
+
+        /// <summary>
+        /// Bool flag indicating that the test assemblies should be shadow copied. 
+        /// Defaults to false.
+        /// </summary>
+        public const string ShadowCopyFiles = "ShadowCopyFiles";
+
+        /// <summary>
+        /// Bool flag indicating that user profile should be loaded on test runner processes
+        /// </summary>
+        public const string LoadUserProfile = "LoadUserProfile";
+
+        /// <summary>
+        /// Bool flag indicating that non-test assemblies should be skipped without error.
+        /// </summary>
+        public const string SkipNonTestAssemblies = "SkipNonTestAssemblies";
+
+        /// <summary>
+        /// Flag (bool) indicating whether to pause execution of tests to allow
+        /// the user to attach a debugger.
+        /// </summary>
+        public const string PauseBeforeRun = "PauseBeforeRun";
+
+        /// <summary>
+        /// The InternalTraceLevel for this run. Values are: "Default",
+        /// "Off", "Error", "Warning", "Info", "Debug", "Verbose".
+        /// Default is "Off". "Debug" and "Verbose" are synonyms.
+        /// </summary>
+        public const string InternalTraceLevel = "InternalTraceLevel";
+
+        /// <summary>
+        /// The PrincipalPolicy to set on the test AppDomain. Values are:
+        /// "UnauthenticatedPrincipal", "NoPrincipal" and "WindowsPrincipal".
+        /// </summary>
+        public const string PrincipalPolicy = "PrincipalPolicy";
+
+        #endregion
+    }
+}

--- a/src/nunit.gui.core/Model/ITestModel.cs
+++ b/src/nunit.gui.core/Model/ITestModel.cs
@@ -81,7 +81,8 @@ namespace NUnit.Gui.Model
         // Do we have results from running the test?
         bool HasResults { get; }
 
-        // List of available runtimes
+        // List of available runtimes, based on the engine's list
+        // but filtered to meet the GUI's requirements
         IList<IRuntimeFramework> AvailableRuntimes { get; }
 
         #endregion

--- a/src/nunit.gui.core/Model/ITestModel.cs
+++ b/src/nunit.gui.core/Model/ITestModel.cs
@@ -78,9 +78,11 @@ namespace NUnit.Gui.Model
         // See if a test is running
         bool IsTestRunning { get; }
 
+        // Do we have results from running the test?
         bool HasResults { get; }
 
-        IList<RuntimeFramework> AvailableRuntimes { get; }
+        // List of available runtimes
+        IList<IRuntimeFramework> AvailableRuntimes { get; }
 
         #endregion
 

--- a/src/nunit.gui.core/XmlHelper.cs
+++ b/src/nunit.gui.core/XmlHelper.cs
@@ -1,0 +1,165 @@
+﻿// ***********************************************************************
+// Copyright (c) 2010-2014 Charlie Poole, Rob Prouse
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Xml;
+
+namespace NUnit
+{
+    /// <summary>
+    /// XmlHelper provides static methods for basic XML operations.
+    /// </summary>
+    public static class XmlHelper
+    {
+        /// <summary>
+        /// Creates a new top level element node.
+        /// </summary>
+        /// <param name="name">The element name.</param>
+        /// <returns>A new XmlNode</returns>
+        public static XmlNode CreateTopLevelElement(string name)
+        {
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml( "<" + name + "/>" );
+            return doc.FirstChild;
+        }
+
+        public static XmlNode CreateXmlNode(string xml)
+        {
+            XmlDocument doc = new XmlDocument();
+            doc.LoadXml(xml);
+            return doc.FirstChild;
+        }
+
+        /// <summary>
+        /// Adds an attribute with a specified name and value to an existing XmlNode.
+        /// </summary>
+        /// <param name="node">The node to which the attribute should be added.</param>
+        /// <param name="name">The name of the attribute.</param>
+        /// <param name="value">The value of the attribute.</param>
+        public static void AddAttribute(this XmlNode node, string name, string value)
+        {
+            XmlAttribute attr = node.OwnerDocument.CreateAttribute(name);
+            attr.Value = value;
+            node.Attributes.Append(attr);
+        }
+
+        /// <summary>
+        /// Adds a new element as a child of an existing XmlNode and returns it.
+        /// </summary>
+        /// <param name="node">The node to which the element should be added.</param>
+        /// <param name="name">The element name.</param>
+        /// <returns>The newly created child element</returns>
+        public static XmlNode AddElement(this XmlNode node, string name)
+        {
+            XmlNode childNode = node.OwnerDocument.CreateElement(name);
+            node.AppendChild(childNode);
+            return childNode;
+        }
+
+        /// <summary>
+        /// Adds the a new element as a child of an existing node and returns it.
+        /// A CDataSection is added to the new element using the data provided.
+        /// </summary>
+        /// <param name="node">The node to which the element should be added.</param>
+        /// <param name="name">The element name.</param>
+        /// <param name="data">The data for the CDataSection.</param>
+        /// <returns></returns>
+        public static XmlNode AddElementWithCDataSection(this XmlNode node, string name, string data)
+        {
+            XmlNode childNode = node.AddElement(name);
+            childNode.AppendChild(node.OwnerDocument.CreateCDataSection(data));
+            return childNode;
+        }
+
+        #region Safe Attribute Access
+
+        /// <summary>
+        /// Gets the value of the given attribute.
+        /// </summary>
+        /// <param name="result">The result.</param>
+        /// <param name="name">The name.</param>
+        /// <returns></returns>
+        public static string GetAttribute(this XmlNode result, string name)
+        {
+            XmlAttribute attr = result.Attributes[name];
+
+            return attr == null ? null : attr.Value;
+        }
+
+        /// <summary>
+        /// Gets the value of the given attribute as an int.
+        /// </summary>
+        /// <param name="result">The result.</param>
+        /// <param name="name">The name.</param>
+        /// <param name="defaultValue">The default value.</param>
+        /// <returns></returns>
+        public static int GetAttribute(this XmlNode result, string name, int defaultValue)
+        {
+            XmlAttribute attr = result.Attributes[name];
+
+            return attr == null
+                ? defaultValue
+                : int.Parse(attr.Value, System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Gets the value of the given attribute as a double.
+        /// </summary>
+        /// <param name="result">The result.</param>
+        /// <param name="name">The name.</param>
+        /// <param name="defaultValue">The default value.</param>
+        /// <returns></returns>
+        public static double GetAttribute(this XmlNode result, string name, double defaultValue)
+        {
+            XmlAttribute attr = result.Attributes[name];
+
+            return attr == null
+                ? defaultValue
+                : double.Parse(attr.Value, System.Globalization.CultureInfo.InvariantCulture);
+        }
+
+        /// <summary>
+        /// Gets the value of the given attribute as a DateTime.
+        /// </summary>
+        /// <param name="result">The result.</param>
+        /// <param name="name">The name.</param>
+        /// <param name="defaultValue">The default value.</param>
+        /// <returns></returns>
+        public static DateTime GetAttribute(this XmlNode result, string name, DateTime defaultValue)
+        {
+            string dateStr = GetAttribute(result, name);
+            if (dateStr == null)
+                return defaultValue;
+
+            DateTime date;
+            if (!DateTime.TryParse(dateStr, CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal | DateTimeStyles.AllowWhiteSpaces, out date))
+                return defaultValue;
+
+            return date;
+        }
+
+        #endregion
+    }
+}

--- a/src/nunit.gui.core/nunit.gui.core.csproj
+++ b/src/nunit.gui.core/nunit.gui.core.csproj
@@ -31,16 +31,8 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Mono.Cecil, Version=0.9.6.0, Culture=neutral, PublicKeyToken=0738eb9f132ed756, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.6.1\lib\Mono.Cecil.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="nunit.engine, Version=3.6.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.6.1\lib\nunit.engine.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
     <Reference Include="nunit.engine.api, Version=3.0.0.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
-      <HintPath>..\..\packages\NUnit.Engine.3.6.1\lib\nunit.engine.api.dll</HintPath>
+      <HintPath>..\..\packages\NUnit.Engine.Api.3.6.1\lib\nunit.engine.api.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="System" />
@@ -53,6 +45,7 @@
       <Link>Properties\CommonAssemblyInfo.cs</Link>
     </Compile>
     <Compile Include="CommandLineOptions.cs" />
+    <Compile Include="EnginePackageSettings.cs" />
     <Compile Include="ExtensionAttribute.cs" />
     <Compile Include="Model\ITestItem.cs" />
     <Compile Include="Model\ITestModel.cs" />
@@ -82,9 +75,7 @@
     <Compile Include="Views\ITestTreeView.cs" />
     <Compile Include="Views\IView.cs" />
     <Compile Include="Views\IXmlView.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
+    <Compile Include="XmlHelper.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\nunit.uikit\nunit.uikit.csproj">
@@ -92,7 +83,9 @@
       <Name>nunit.uikit</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/src/nunit.gui.core/packages.config
+++ b/src/nunit.gui.core/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NUnit.Engine" version="3.6.1" targetFramework="net20" />
+  <package id="NUnit.Engine.Api" version="3.6.1" targetFramework="net20" />
 </packages>


### PR DESCRIPTION
Fixes #209 

The GUI no longer uses the `RuntimeFramework` type but instead accesses the `IAvailableRuntimes` service. As a result, the reference to the engine itself has been removed from both the `nunit.gui.core` and `nunit-gui` projects.